### PR TITLE
fix(default day): Fix failing test for API calls without speficic day

### DIFF
--- a/lib/moves.rb
+++ b/lib/moves.rb
@@ -49,6 +49,8 @@ module Moves
           ["/#{args[0].strftime(format)}", args[1]]
         elsif args[0].is_a?(Range)
           ["", {:from => args[0].first, to: args[0].last}]
+        elsif args.compact.empty?
+          ["", nil]
         else
           ["/#{args[0]}", args[1]]
         end


### PR DESCRIPTION
Set extra_path to an empty string in order to fallback to 'today' when no date is explictly given.

There might be a cleaner way to achieve, let me know if you want me to change something.
